### PR TITLE
Add options for configuring code blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ test-harness/docbox/**
 test-harness/testbox/**
 test-harness/logs/**
 test-harness/modules/**
+modules/*
 
 # log files
 logs/**

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -50,7 +50,7 @@ component {
 			// default null, custom inline code close HTML
 			codeStyleHTMLClose		 : '</code>',
 			// default "language-", prefix used for generating the <code> class for a fenced code block, only used if info is not empty and language is not defined in
-			fencedCodeLanguageClassPrefix : "brush: ",
+			fencedCodeLanguageClassPrefix : "language-",
 			// Table options
 			tableOptions             : {
 				// Treat consecutive pipes at the end of a column as defining spanning column.

--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -45,6 +45,12 @@ component {
 			anchorSuffix             : "",
 			// Enable youtube embedded link transformer
 			enableYouTubeTransformer : false,
+			// default null, custom inline code open HTML
+			codeStyleHTMLOpen		 : '<code>',
+			// default null, custom inline code close HTML
+			codeStyleHTMLClose		 : '</code>',
+			// default "language-", prefix used for generating the <code> class for a fenced code block, only used if info is not empty and language is not defined in
+			fencedCodeLanguageClassPrefix : "brush: ",
 			// Table options
 			tableOptions             : {
 				// Treat consecutive pipes at the end of a column as defining spanning column.

--- a/models/Processor.cfc
+++ b/models/Processor.cfc
@@ -145,6 +145,27 @@ component accessors=true singleton {
 				anchorLinkExtension.ANCHORLINKS_TEXT_SUFFIX,
 				arguments.options.anchorSuffix
 			)
+			.set(
+				variables.StaticParser.CODE_STYLE_HTML_OPEN,
+				javacast(
+					"string",
+					arguments.options.codeStyleHTMLOpen
+				)
+			)
+			.set(
+				variables.StaticParser.CODE_STYLE_HTML_CLOSE,
+				javacast(
+					"string",
+					arguments.options.codeStyleHTMLClose
+				)
+			)
+			.set(
+				variables.StaticParser.FENCED_CODE_LANGUAGE_CLASS_PREFIX,
+				javacast(
+					"string",
+					arguments.options.fencedCodeLanguageClassPrefix
+				)
+			)
 			// Add Table Options
 			.set(
 				staticTableExtension.COLUMN_SPANS,

--- a/models/Processor.cfc
+++ b/models/Processor.cfc
@@ -146,21 +146,21 @@ component accessors=true singleton {
 				arguments.options.anchorSuffix
 			)
 			.set(
-				variables.StaticParser.CODE_STYLE_HTML_OPEN,
+				variables.HtmlRenderer.CODE_STYLE_HTML_OPEN,
 				javacast(
 					"string",
 					arguments.options.codeStyleHTMLOpen
 				)
 			)
 			.set(
-				variables.StaticParser.CODE_STYLE_HTML_CLOSE,
+				variables.HtmlRenderer.CODE_STYLE_HTML_CLOSE,
 				javacast(
 					"string",
 					arguments.options.codeStyleHTMLClose
 				)
 			)
 			.set(
-				variables.StaticParser.FENCED_CODE_LANGUAGE_CLASS_PREFIX,
+				variables.HtmlRenderer.FENCED_CODE_LANGUAGE_CLASS_PREFIX,
 				javacast(
 					"string",
 					arguments.options.fencedCodeLanguageClassPrefix

--- a/readme.md
+++ b/readme.md
@@ -60,6 +60,12 @@ moduleSettings = {
 		anchorSuffix             : "",
 		// Enable youtube embedded link transformer
 		enableYouTubeTransformer : false,
+		// override HTML to use for wrapping style.
+		codeStyleHTMLOpen		 : '<code class="code inline">',
+		// override HTML to use for wrapping style.
+		codeStyleHTMLClose		 : '</code>',
+		// add a class prefix to the "fenced" code blocks, i.e. ```js. Useful for supporting various syntax highlighters.
+		fencedCodeLanguageClassPrefix : "brush",
 		// Table options
 		tableOptions             : {
 			// Treat consecutive pipes at the end of a column as defining spanning column.

--- a/test-harness/layouts/Main.cfm
+++ b/test-harness/layouts/Main.cfm
@@ -3,4 +3,9 @@
 <div>
 	#renderView()#
 </div>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.4.0/highlight.min.js" integrity="sha512-IaaKO80nPNs5j+VLxd42eK/7sYuXQmr+fyywCNA0e+C6gtQnuCXNtORe9xR4LqGPz5U9VpH+ff41wKs/ZmC3iA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.4.0/languages/javascript.min.js" integrity="sha512-Z5vOg00atIeZ04QhYxz3iRlFnU5qnrB0eYbBDmXMhHqJYx4dc6n1KY5qzh3fEfrFzaR05D34mOin6ObjPjuWdA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.4.0/styles/default.min.css" integrity="sha512-hasIneQUHlh06VNBe7f6ZcHmeRTLIaQWFd43YriJ0UND19bvYRauxthDg8E4eVNPm9bRUhr5JGeqH7FRFXQu5g==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
+<script>hljs.highlightAll();</script>
 </cfoutput>


### PR DESCRIPTION
This PR adds support for three flexmark options related to code formatting:

* `codeStyleHTMLOpen` - translates to `HtmlRenderer.CODE_STYLE_HTML_OPEN` - Allow custom HTML for the opening tag around inline code.
* `codeStyleHTMLClose` - translates to `HtmlRenderer.CODE_STYLE_HTML_CLOSE` - Allow custom HTML for the closing tag around inline code.
* `fencedCodeLanguageClassPrefix` - translates to `HtmlRenderer.FENCED_CODE_LANGUAGE_CLASS_PREFIX` - default "language-", prefix used for generating the `<code>` class for a fenced code block, only used if code language is specified.

See [Flexmark Configuration Options](https://github.com/vsch/flexmark-java/wiki/Extensions#configuring-options) for more details.